### PR TITLE
フッターのCopyrightをGitHubアカウント名に修正

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,7 +3,7 @@
     <div class="row copyright">
       <div class="col-md-12 text-center">
         <p>
-          <small class="block">&copy; 2020 Your Name All Rights Reserved.</small>
+          <small class="block">&copy; 2020 tkp14 All Rights Reserved.</small>
         </p>
       </div>
     </div>


### PR DESCRIPTION
ページフッターのCopyrightが"Your Name"となっていたので、GitHubのアカウント名に修正しました。
[こちら](https://www.weblab.co.jp/staff/marketing/10353.html)によると、著作権者の名前は本名でなくても問題ないようですので、GitHubのアカウント名としました。